### PR TITLE
Corrected issues with sed reserved characters

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
 FROM nginx:1.10.1-alpine
 
 # Default http protocol
-ENV HTTP_PROTOCOL http
-ENV HTTP_PATH /
+ENV HTTP_PROTOCOL=http \
+    FILTER_PATH=0
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/default.conf
+++ b/default.conf
@@ -2,7 +2,11 @@ server {
   listen 80;
   server_name docker;
 
-  location <target_path_placeholder> {
+  location / {
+    # add a filter block if applicable.
+    <filter_block>
+
+    # set up the reverse proxy.
     proxy_pass              <proxy_pass_protocol_placeholder>://<proxy_pass_placeholder>;
     proxy_set_header        Host <host_placeholder>;
     proxy_set_header        X-Real-IP $remote_addr;
@@ -16,6 +20,5 @@ server {
 
     proxy_set_header        Upgrade $http_upgrade;
     proxy_set_header        Connection "upgrade";
-
   }
 }

--- a/start.sh
+++ b/start.sh
@@ -2,9 +2,34 @@
 
 HOST_SERVER=${HOST_SERVER:-\$host}
 
-/bin/sed -i "s/<target_path_placeholder>/${HTTP_PATH}/" /etc/nginx/conf.d/default.conf
-/bin/sed -i "s/<proxy_pass_protocol_placeholder>/${HTTP_PROTOCOL}/" /etc/nginx/conf.d/default.conf
-/bin/sed -i "s/<proxy_pass_placeholder>/${TARGET_SERVER}/" /etc/nginx/conf.d/default.conf
-/bin/sed -i "s/<host_placeholder>/${HOST_SERVER}/" /etc/nginx/conf.d/default.conf
+# Extract the protocol (includes trailing "://").
+PARSED_PROTO="$(echo $TARGET_SERVER | sed -nr 's,^(.*://).*,\1,p')"
+# Remove the protocol from the URL.
+PARSED_URL="$(echo ${TARGET_SERVER/$PARSED_PROTO/})"
+# Extract the user (includes trailing "@").
+PARSED_USER="$(echo $PARSED_URL | sed -nr 's,^(.*@).*,\1,p')"
+# Remove the user from the URL.
+PARSED_URL="$(echo ${PARSED_URL/$PARSED_USER/})"
+# Extract the port (includes leading ":").
+PARSED_PORT="$(echo $PARSED_URL | sed -nr 's,.*(:[0-9]+).*,\1,p')"
+# Remove the port from the URL.
+PARSED_URL="$(echo ${PARSED_URL/$PARSED_PORT/})"
+# Extract the path (includes leading "/" or ":").
+PARSED_PATH="$(echo $PARSED_URL | sed -nr 's,[^/:]*([/:].*),\1,p')"
+# Remove the path from the URL.
+PARSED_HOST="$(echo ${PARSED_URL/$PARSED_PATH/})"
+
+# define the default config file once.
+CONF_FILE="/etc/nginx/conf.d/default.conf"
+
+# perform the substitution.
+if [ ! -z ${PARSED_PATH} ] && [ ${FILTER_PATH} -eq 1 ]; then
+  /bin/sed -i "s,<filter_block>,sub_filter\t${PARSED_PATH} /;\n    sub_filter_types\t*;\n    sub_filter_once\toff;," ${CONF_FILE}
+else
+  /bin/sed -i "s,<filter_block>,," ${CONF_FILE}
+fi;
+/bin/sed -i "s,<proxy_pass_protocol_placeholder>,${HTTP_PROTOCOL}," ${CONF_FILE}
+/bin/sed -i "s,<proxy_pass_placeholder>,${TARGET_SERVER}," ${CONF_FILE}
+/bin/sed -i "s,<host_placeholder>,${HOST_SERVER}," ${CONF_FILE}
 
 nginx -g "daemon off;"


### PR DESCRIPTION
# Corrected issues with sed reserved characters
This was causing the ```TARGET_SERVER``` to perform incorrect sed substitution. Fixed it by using a different separator ```,``` instead of the ```/```. This means that paths can now be directly entered into the ```TARGET_SERVER``` variable, as such:
```
TARGET_SERVER=0.0.0.0:000/path
```
# Added path filtering
On some instances, such as it is the case with Plex, proxying into a path is not enough, because the http files have the path hardcoded. Adding a filter block allows for those URLs to be rewritten in the response, allowing the assets to be loaded correctly. There might be some tweaks to make here, but the initial implementation seems to be working.

In order to use the functionality, a path must be used in ```TARGET_SERVER``` and the ```FILTER_PATH``` variable must be set to 1 (this is a safeguard, to ensure filtering is not done by default).

A new ```TARGET_SERVER```  URL-parsing block has been added to ```start.sh``` it can successfully dissect every part of the URL allowing for better future substitutions if needed. I am only using the path parsing part of it at the moment.

# Other changes
Removed the ```HTTP_PATH``` variable, as it can now be extracted from the ```TARGET_SERVER``` parsing block.